### PR TITLE
Wait for tshark to capture the test packets

### DIFF
--- a/lab1/part1/provided/capture_submission.sh
+++ b/lab1/part1/provided/capture_submission.sh
@@ -115,7 +115,8 @@ docker exec clab-lab1-part1-host1 /lab-folder/onepkt.py host1 host3 test-pkt4
 # host4 to all
 docker exec clab-lab1-part1-host4 /lab-folder/onepkt.py host4 all_hosts test-pkt5
 
-
+# Wait for tshark to capture the test packets
+sleep 10s
 
 # Stop captures
 kill $pid1


### PR DESCRIPTION
I struggled to get lab1 to pass in the coursera grader, and got a tip from the student Slack group that the tshark captures may have been killed before they were able to record the test packets. I verified that with a sleep in `capture_submission.sh`, tshark had time to record all the expected packets, and without, some packets were missing.