### PR TITLE
Fixed typo in Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,6 +90,6 @@ end
 
 
 # Optional (suggest allowing non root user to capture packets):
-# sudo apt install wireshark-qy 
+# sudo apt install wireshark-qt
 # sudo cp .Xauthority /root
 # sudo wireshark &


### PR DESCRIPTION
Changed `sudo apt get install wireshark-qy` to `sudo apt get install wireshark-qt`. You can imagine this took me a lot of time and effort.