### PR TITLE
New method for Apple silicon (M1 or newer ARM64) processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,18 @@ vagrant up
 ```
 
 
-Configure your ssh client with the following.  I use [MobaXterm](https://mobaxterm.mobatek.net/).
+Configure your ssh client with the following.  I use [MobaXterm](https://mobaxterm.mobatek.net/). For Mac users, [Termius](https://apps.apple.com/us/app/termius-modern-ssh-client/id1176074088?mt=12) is recommended.
+
 Hostname/IP address: 127.0.0.1
+
 Port number: 2222
+
 Username: vagrant
+
 Private Key: <path/to/private_key>
+
 Note: you’ll want x11 forwarding on
+
 
 To get the location of the private key:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This set of demos and lab goes along with the coursera course: `Network Principles in Practice: Linux`.  You are welcome to run this code and I try to make it as self explanatory as possible, but some of the explanation will be in the videos for the course.
 
-NOTE: Mac M1/M2 users should refer to the guidance [here](/mac-arm/README.md)
+NOTE: Mac M1 or newer (Any Mac released since November 2020 and on) users should refer to the guidance [here](/mac-arm/README.md)
 
 # Vagrantfile
 

--- a/Vagrantfile-macos
+++ b/Vagrantfile-macos
@@ -1,0 +1,20 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2204"
+  config.vm.provider "qemu" do |qe|
+    qe.arch = "x86_64"
+    qe.machine = "q35"
+    qe.cpu = "max"
+    qe.net_device = "virtio-net-pci"
+    qe.ssh_port = "2222"
+  end
+  config.vm.provision "shell", inline: <<-SHELL
+     apt update
+     apt install net-tools
+     sudo apt-get install ca-certificates curl
+     curl -fsSL https://get.docker.com -o get-docker.sh
+     sh get-docker.sh
+     usermod -aG docker vagrant 
+     newgrp docker
+     bash -c "$(curl -sL https://get.containerlab.dev)" -- -v 0.44.0
+  SHELL
+end

--- a/mac-arm/README.md
+++ b/mac-arm/README.md
@@ -1,78 +1,44 @@
 # Introduction
 
-This readme includes guidance for users using Mac M1/M2 (ARM) machines and working with the demos/labs for the coursera course: `Network Principles in Practice: Linux`.
+This readme includes guidance for users using Mac M1 processors (ARM) or newer machines and working with the demos/labs for the coursera course: `Network Principles in Practice: Linux`.
 
-The standard approach for the course labs is to use Vagrant VMs (with VirtualBox) which include multiple tools, including a containerlabs installation.
+The approach that is being provided for the course labs is to use Vagrant VMs that are based on VirtualBox in order to run everything.
 
-This approach can experience various difficulties running properly on Mac M1/M2 (ARM) machines.  One of the primary issues being that containerlabs does not currently provide native support for Mac ARM.
+This approach can experience various difficulties running properly on Mac M1/M2 (ARM) machines. The main issue is that the method here will try to create the VM using an x64 image, while VirtualBox is unable to emulate x64 images on ARM (Mac's with M1 processors or newer).
 
-As a course supported alternative, the following guidance is derived from the containerlabs guidance [here](https://containerlab.dev/install/#arm) and can be used for running the course demos/labs on Mac M1/M2.  This approach utilizes UTM and Ubuntu.
+In order to be able to create a x64 virtual machine on ARM processor (Apple Silicon, M1 or newer), we need to first install QEMU which will be able to do the needed emulation and to use a suitable Vagrandfile. The new Vagrandfile is based on another image that is compatible with QEMU, which is our only way to emulate x64 images. The format of the file is also different compared to the original Vagrandfile, as QEMU has different calls compared to VirtualBox (The original Vagrandfile).
 
-# UTM
 
-UTM is a popular system emulator and virtual machine host for macOS.
 
-This will provide an alternative to Vagrant/VirtualBox and will allow you to build and run an emulated x86_64 Linux machine on Mac M1/M2 (ARM) machines.
+# QEMU
 
-You can get and install UTM [here](https://mac.getutm.app/).
+QEMU is an emulation tool that is available on both Linux distributions and MacOS that is able to emulate x64 images on ARM processors (in our case, Apple Silicon - M1 or newer processors).
 
-# Ubuntu 22.04
 
-Containerlab provides a custom built debian image to support running on ARM.
+This will allow us to setup everything that is needed just like you are using it on a normal x64 computer without almost any change to the process
 
-The course supported guidance recognizes this may work for the demos/labs but this guidance suggests to build a UTM machine with Ubuntu 22.04, to minimize any differences with the original Vagrant build for these labs.
 
-Download the Ubuntu 22.04 **Server install image** ISO [here](https://www.releases.ubuntu.com/22.04/).
+We will need to install QEMU that will handle all the emulations instead of VirtualBox, Vagrand which we will use in this course and the QEMU Vagrand plugin that will allow Vagrand to communicate with QEMU and control the VM's.
 
-**DO NOT** use the Desktop image.  It will perform significantly slower than the Server image within UTM.
 
-# Ubuntu VM Image Build Process via UTM
+First, we will install brew. Brew is a packet manager that will allow us to install all the softwares we need.
 
-1. Install UTM
-2. Download Ubuntu 22.04 amd64 ISO
-3. Add machine to UTM using Emulate Linux options
-4. Mount Ubuntu ISO
-5. Use remaining UTM defaults
-6. Start VM
-7. Complete Ubuntu Install using installer defaults
-8. Use 'vagrant' for the server name, user name, and password to minimize any differences with the Vagrant build
-9. Once the Ubuntu installation is complete, it will ask to reboot.  Do not do this.  Instead, shut the VM down and then unmount the iso in UTM before starting the VM again. If you reboot while the iso is still mounted, the installation will start again
-10. Start the VM and confirm you can login
-11. Recommended to shut the VM down again and then clone that image within UTM to have a clean copy to start setup for each lab
-12. Recommended to check and change the MAC Address configuration for each lab VM within UTM.  The Random generation option can be used.  Otherwise multiple VMs running concurrently in UTM could have conflicting MAC addresses
-
-# Demo/Lab Setup
-Once the above is completed, you should have a clean UTM/Ubuntu VM ready to start any setup required for each demo/lab.
-
-To finish the setup for a given demo/lab on the VM, install any additional required components on the VM first.  Check the provision shell block in the Vagrantfile to see the installation commands.  Execute each line of that block individually on the VM.  You may find you need to run the line as sudo and each line should succeed before executing the next line.
-
-For example, given a Vagrantfile provision shell block as follows:
+In order to install brew, open Terminal in your mac, and run the following:
 ```
-config.vm.provision "shell", inline: <<-SHELL
-  apt update
-	 apt install net-tools
-  curl -fsSL https://get.docker.com -o get-docker.sh
-  sh get-docker.sh --version 24.0.5
-	 usermod -aG docker vagrant 
-	 newgrp docker
-	 bash -c "$(curl -sL https://get.containerlab.dev)" -- -v 0.44.0
-  SHELL
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
-you can run:
+When installation is finished, run the following commands one by one:
 ```
-sudo apt update
-sudo apt install net-tools
-curl -fsSL https://get.docker.com -o get-docker.sh
-sudo sh get-docker.sh --version 24.0.5
-sudo usermod -aG docker vagrant 
-sudo newgrp docker
-sudo bash -c "$(curl -sL https://get.containerlab.dev)" -- -v 0.44.0
+brew install qemu
+brew install --cask vagrant
+vagrant plugin install vagrant-qemu
 ```
+The first command tells brew to install qemu, the 2nd command tells brew to install Vagrant and the 3rd command tells Vagrant to install the QEMU plugin.
 
-Once the above is completed, you can clone the git repo for a given demo/lab within the VM.
 
-At this point you can bypass any Vagrant commands and can run the demo/lab as if you had already run `vagrant up` and connected to the VM via ssh.
+When the installation is over, clone the repository (or download it as ZIP), delete Vagrandfile, and rename Vagrandfile-macos to Vagrandfile.
+
+And that's it! you are ready to go
 
 # License
-
 For all files in this repo, we follow the MIT license.  See LICENSE file.

--- a/mac-arm/README.md
+++ b/mac-arm/README.md
@@ -4,7 +4,7 @@ This readme includes guidance for users using Mac M1 processors (ARM) or newer m
 
 The approach that is being provided for the course labs is to use Vagrant VMs that are based on VirtualBox in order to run everything.
 
-This approach can experience various difficulties running properly on Mac M1/M2 (ARM) machines. The main issue is that the method here will try to create the VM using an x64 image, while VirtualBox is unable to emulate x64 images on ARM (Mac's with M1 processors or newer).
+This approach can experience various difficulties running properly on Mac M1 (ARM) or newer machines. The main issue is that the method here will try to create the VM using an x64 image, while VirtualBox is unable to emulate x64 images on ARM (Mac's with M1 processors or newer).
 
 In order to be able to create a x64 virtual machine on ARM processor (Apple Silicon, M1 or newer), we need to first install QEMU which will be able to do the needed emulation and to use a suitable Vagrandfile. The new Vagrandfile is based on another image that is compatible with QEMU, which is our only way to emulate x64 images. The format of the file is also different compared to the original Vagrandfile, as QEMU has different calls compared to VirtualBox (The original Vagrandfile).
 


### PR DESCRIPTION
I was able to develop a new method to setup everything in such a way that it's still simple and the end result allow the student to keep doing the course the same way as a windows user would do.

In order for it to work, there is a need to install brew, Vagrant, QEMU and QEMU plugin for Vagrant. Brew will allow us to install all the needed programs, QEMU allow us to do x64 image emulation on ARM processor such as M1 or newer and the QEMU plugin will allow Vagrant to communicate with QEMU in order to create the VM's.

There was a need to also create an edited Vagrantfile that is based on a different image of Ubuntu(general/ubuntu2204) due to that image having support in QEMU, while the original image didn't support QEMU. Due to the fact that QEMU works differently compared to VirtualBox, the Vagrantfile also needed to be adapted besides the image so QEMU will understand from Vagrant how to create the VM.

I tested everything on my MacBook Pro 16 M2 Pro machine and it works flawlessly.